### PR TITLE
Fix voor raw_d is NoneType omdat mijnafvalwijzer geen jaartal retourneert

### DIFF
--- a/mijnafvalwijzer-to-ical.py
+++ b/mijnafvalwijzer-to-ical.py
@@ -65,8 +65,8 @@ for item in aw.find_all("a", "wasteInfoIcon textDecorationNone"):
         waste_type = item.p["class"][0]
 
     if not waste_types or waste_type in waste_types:
-      raw_d = re.search("(\w+) (\d+) (\w+) (\d+)", item.p.text)
-      item_date = date(int(raw_d.group(4)), months.get(raw_d.group(3), 0), int(raw_d.group(2)))
+      raw_d = re.search("(\w+) (\d+) (\w+)", item.p.text)
+      item_date = date(datetime.date.today().year, months.get(raw_d.group(3), 0), int(raw_d.group(2)))
       item_descr = item.find("span", {"class": "afvaldescr"}).text
 
       event = Event()


### PR DESCRIPTION
Hoi vwout, ik wilde je script gebruiken om een iCal te maken voor het ophaalschema hier in onze buurt, maar helaas werkte het niet, omdat het script ervan uitgaat dat mijnafvalwijzer een datum retourneert inclusief jaartal ("18 maart 2023"). Doordat mijnafvalwijzer niet langer een jaartal terugstuurt (in elk geval niet in deze regio), faalt de regex. Heb daar nu een vrij naïeve workaround voor geschreven, misschien heb je er iets aan. :)