### PR TITLE
Enhance argument parsing and output functionality

### DIFF
--- a/mijnafvalwijzer-to-ical.py
+++ b/mijnafvalwijzer-to-ical.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 import sys
 import re
 import requests
@@ -22,17 +21,25 @@ months = {
   "december":  12
 }
 
-if len(sys.argv) < 2:
-    print("Usage {0} <postal code> <house number>".format(sys.argv[0]))
+if len(sys.argv) < 3:
+    print("Usage: {0} <postal code> <house number> [waste_types] [--output filename.ics]".format(sys.argv[0]))
+    print("Example: {0} 9675JL 9B gft,papier,pmd,restafval".format(sys.argv[0]))
+    print("Example: {0} 9675JL 9B gft,papier,pmd,restafval --output afval.ics".format(sys.argv[0]))
     exit(1)
 
 postal_code = sys.argv[1]
 housenumber = sys.argv[2]
 housenumber_suffix = ""
 waste_types = []
+output_file = None
 
-if len(sys.argv) >= 4:
-  waste_types = sys.argv[3].split(",")
+# Parse arguments
+for i in range(3, len(sys.argv)):
+    if sys.argv[i] == "--output" or sys.argv[i] == "-o":
+        if i + 1 < len(sys.argv):
+            output_file = sys.argv[i + 1]
+    elif "," in sys.argv[i] or sys.argv[i] in ["gft", "papier", "pmd", "restafval"]:
+        waste_types = sys.argv[i].split(",")
 
 housenumber_re = re.search(r"^(\d+)(\D*)$", housenumber)
 if housenumber_re.group():
@@ -65,7 +72,7 @@ for item in aw.find_all("a", "wasteInfoIcon textDecorationNone"):
         waste_type = item.p["class"][0]
 
     if not waste_types or waste_type in waste_types:
-      raw_d = re.search("(\w+) (\d+) (\w+)( (\d+))?", item.p.text)
+      raw_d = re.search(r"(\w+) (\d+) (\w+)( (\d+))?", item.p.text)
       item_date = date(int(raw_d.group(5) or date.today().year), months.get(raw_d.group(3), 0), int(raw_d.group(2)))
       item_descr = item.find("span", {"class": "afvaldescr"}).text
 
@@ -74,10 +81,18 @@ for item in aw.find_all("a", "wasteInfoIcon textDecorationNone"):
       event.add("dtstamp", datetime.now())
       event.add("dtstart", item_date)
       event.add("dtend", item_date + timedelta(1))
-      event.add("summary", "Afval - {0}".format(item_descr.replace("\,", ",")))
-      event.add("description", item_descr.replace("\,", ","))
+      event.add("summary", "Afval - {0}".format(item_descr))
+      event.add("description", item_descr)
       event.add_component(alarm)
 
       cal.add_component(event)
 
-print(cal.to_ical().decode("utf-8"))
+# Output the calendar
+ical_data = cal.to_ical().decode("utf-8")
+
+if output_file:
+    with open(output_file, 'w', encoding='utf-8') as f:
+        f.write(ical_data)
+    print("Calendar exported to: {0}".format(output_file))
+else:
+    print(ical_data)


### PR DESCRIPTION
## Fix invalid escape sequence warnings and add file export option

### Changes
- Fixed `SyntaxWarning: invalid escape sequence '\w'` by using raw string (`r""`) for regex pattern
- Removed unnecessary comma replace logic that was already handled by icalendar library
- Added `--output` / `-o` flag to export calendar directly to .ics file instead of printing to console

### Usage
```bash
# Print to console (default)
python3 mijnafvalwijzer-to-ical.py 1234AB 1A gft,papier,pmd,restafval

# Export to file
python3 mijnafvalwijzer-to-ical.py 1234AB 1A gft,papier,pmd,restafval --output afval.ics
```

### Technical Details
- Regex patterns now use raw strings to prevent Python escape sequence interpretation
- icalendar library handles comma escaping automatically per RFC 5545 specification
- Output flag parsing supports flexible argument order